### PR TITLE
update: Added skip text functionality

### DIFF
--- a/levels/levels.go
+++ b/levels/levels.go
@@ -36,9 +36,9 @@ type Level struct {
 	TestCmd      string `yaml:"test"`
 }
 
-func (level *Level) Print() {
+func (level *Level) Print(pretty_print_flag bool) {
 	terminalized_text := MarkdownToTerminal(level.Text)
-	PrintText(terminalized_text)
+	PrintText(terminalized_text, pretty_print_flag)
 }
 
 type Challenge struct {
@@ -71,8 +71,8 @@ func (c *Challenge) CheckCurrentLevel() bool {
 	return CmdOK(c.Levels[level].TestCmd)
 }
 
-func (c *Challenge) PrintCurrentLevel() {
-	c.Levels[c.IDToIndex(*c.CurrentLevel)].Print()
+func (c *Challenge) PrintCurrentLevel(pretty_print_flag bool) {
+	c.Levels[c.IDToIndex(*c.CurrentLevel)].Print(pretty_print_flag)
 }
 
 func (c *Challenge) IncreaseLevel() {

--- a/levels/utils.go
+++ b/levels/utils.go
@@ -1,9 +1,13 @@
 package levels
 
 import (
+	"fmt"
+	"os"
 	"os/exec"
+	"os/signal"
 	"regexp"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -12,9 +16,28 @@ func CmdOK(cmd string) bool {
 	return err == nil
 }
 
-func print_line(text string) {
+var key_pressed = false
+
+func print_line(text string, keypress chan []byte, echo_state bool) {
+	var counter = 0
+	var b []byte = make([]byte, 1)
 	for _, char := range text {
 		print(string(char))
+		if echo_state == false {
+			counter++
+			go func() { os.Stdin.Read(b); keypress <- b }()
+			select {
+			case key := <-keypress:
+				// only skip if enter or space was pressed
+				if key[0] == 10 || key[0] == 32 {
+					key_pressed = true
+					fmt.Println(text[counter:len(text)])
+					return
+				}
+			default:
+				fmt.Print("")
+			}
+		}
 		time.Sleep(50 * time.Millisecond)
 		if char == '.' || char == '!' || char == '?' {
 			time.Sleep(500 * time.Millisecond)
@@ -23,10 +46,40 @@ func print_line(text string) {
 	print("\n")
 }
 
-func PrintText(text string) {
+func PrintText(text string, pretty_print bool) {
+	var echo_state bool = true
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigs
+		if echo_state == false {
+			exec.Command("stty", "-F", "/dev/tty", "echo").Run()
+		}
+		os.Exit(0)
+	}()
+
+	if pretty_print == false {
+		// disable input buffering
+		err := exec.Command("stty", "-F", "/dev/tty", "cbreak", "min", "1").Run()
+		if err == nil {
+			// do not display entered characters on the screen
+			exec.Command("stty", "-F", "/dev/tty", "-echo").Run()
+			echo_state = false
+			// restore the echoing state when exiting
+			defer exec.Command("stty", "-F", "/dev/tty", "echo").Run()
+		}
+	}
+
+	keypress := make(chan []byte, 1)
 	lines := strings.Split(text, "\n")
+	var counter = 0
 	for _, line := range lines {
-		print_line(line)
+		counter += len(line) + 1
+		print_line(line, keypress, echo_state)
+		if key_pressed {
+			fmt.Println(text[counter:len(text)])
+			break
+		}
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -9,6 +9,8 @@ import (
 
 func main() {
 	print_flag := flag.Bool("print", false, "print loaded levels and exit")
+	pretty_print_flag := flag.Bool("no-pretty-print", false,
+		"disable option to skip pretty printing")
 	flag.Parse()
 
 	if len(flag.Args()) < 1 {
@@ -31,7 +33,7 @@ func main() {
 	challenge.LoadCfg()
 
 	if challenge.CheckCurrentLevel() {
-		challenge.PrintCurrentLevel()
+		challenge.PrintCurrentLevel(*pretty_print_flag)
 		challenge.IncreaseLevel()
 	}
 


### PR DESCRIPTION
- Added functionality when user presses a key a slow printing of a text is
  skipped and whole text is printed at once. This is done by dirty hack of
  putting terminal into raw mode and listing to key presses
