### PR TITLE
fix: fixed counter exceding length of text

### DIFF
--- a/levels/utils.go
+++ b/levels/utils.go
@@ -78,6 +78,9 @@ func PrintText(text string, pretty_print bool) {
 	var counter = 0
 	for _, line := range lines {
 		counter += len(line) + 1
+		if counter > len(text) {
+			counter = len(text)
+		}
 		print_line(line, keypress, echo_state)
 		if key_pressed {
 			fmt.Println(text[counter:len(text)])

--- a/levels/utils.go
+++ b/levels/utils.go
@@ -25,7 +25,7 @@ func print_line(text string, keypress chan []byte, echo_state bool) {
 	var counter = 0
 	var b []byte = make([]byte, 1)
 	for _, char := range text {
-		print(string(char))
+		fmt.Printf("%s", string(char))
 		if echo_state == false {
 			counter++
 			go func() { os.Stdin.Read(b); keypress <- b }()
@@ -46,7 +46,7 @@ func print_line(text string, keypress chan []byte, echo_state bool) {
 			time.Sleep(500 * time.Millisecond)
 		}
 	}
-	print("\n")
+	fmt.Println()
 }
 
 func PrintText(text string, pretty_print bool) {
@@ -74,6 +74,10 @@ func PrintText(text string, pretty_print bool) {
 	}
 
 	keypress := make(chan []byte, 1)
+	PrettyPrintText(text, keypress, echo_state)
+}
+
+func PrettyPrintText(text string, keypress chan []byte, echo_state bool) {
 	lines := strings.Split(text, "\n")
 	var counter = 0
 	for _, line := range lines {

--- a/print_test.go
+++ b/print_test.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"./levels"
+)
+
+// Test that tries to simulate condition with "last line counter overflow"
+// where if user tried to skip text on last line of level description
+// counter would exceed length of text and panic with index out of bounds
+// would follow.
+func ExampleLastLineCounterOverflow() {
+	keypress := make(chan []byte, 1)
+	markdown_text := levels.MarkdownToTerminal("testing sequence for last" +
+		" line counter overflow")
+	go func() {
+		var space = []byte{10}
+		keypress <- space
+	}()
+	levels.PrettyPrintText(markdown_text, keypress, false)
+	// Output:
+	// testing sequence for last line counter overflow
+}


### PR DESCRIPTION
- Fixed counter for skipping text exceeding total length of text
  when key was pressed on last line
