### PR TITLE
update: Rename template generation flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,6 +24,8 @@ func main() {
 	decrypt_flag := flag.Bool("dec", false, "decrypt a given challenge")
 	template_flag := flag.Bool("generate-from-template", false,
 		"generate content of a .gta file from given template file and variables file")
+	flag.BoolVar(template_flag, "g", false,
+		"generate content of a .gta file from given template file and variables file")
 	print_identifier_flag := flag.Bool("print-identifier", false,
 		"print level identifier and exit")
 

--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ func main() {
 		"detect a level from a given hash and home directory")
 	encrypt_flag := flag.Bool("enc", false, "encrypt a given challenge")
 	decrypt_flag := flag.Bool("dec", false, "decrypt a given challenge")
-	template_flag := flag.Bool("temp", false,
+	template_flag := flag.Bool("generate-from-template", false,
 		"generate content of a .gta file from given template file and variables file")
 	print_identifier_flag := flag.Bool("print-identifier", false,
 		"print level identifier and exit")


### PR DESCRIPTION
* Previously, the template generation flag was called `temp`. That did
  not say much about its fuction and so this commit changes that to
  `generate-from-template`.

Signed-off-by: mr.Shu <mr@shu.io>