### PR TITLE
fix: don't sanitize HTML in template generation

### DIFF
--- a/levels/template.go
+++ b/levels/template.go
@@ -3,7 +3,7 @@ package levels
 import (
 	"fmt"
 	"gopkg.in/yaml.v2"
-	"html/template"
+	"text/template"
 	"os"
 	"reflect"
 	"strings"


### PR DESCRIPTION
* The `go/html` package automatically sanitizes the output to produce safe HTML. Which in some cases can break some of the levels. For example, it change `'<'` to `'&lt;'`.
* Based on https://stackoverflow.com/questions/48527115/template-unnecessarily-escaping-to-lt-but-not there is not way to turn it off for `html/template`. But, we should be probably good with just using `text/template` without all the fancy HTML stuff
* Replaced package html/template for just text/template